### PR TITLE
Fix `expo-router/babel` plugin not loading

### DIFF
--- a/txcdr-client/babel.config.js
+++ b/txcdr-client/babel.config.js
@@ -2,7 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ["babel-preset-expo"],
-    plugins: ["expo-router/babel"],
-    plugins: ["nativewind/babel"],
+    plugins: ["expo-router/babel", "nativewind/babel"],
   };
 };


### PR DESCRIPTION
# Overview
Made a tiny but large oopsie in the last PR that prevented bundling

# Changes
- Fixed the mistake in `babel.config.js`

# Testing
Tested on Expo Go for Pixel 3a emulator and iOS with a clear cache