### PR TITLE
Add map display, embedded ZIP code searching, annotation pins, and event card

### DIFF
--- a/txcdr-client/app/map/EventCallout.tsx
+++ b/txcdr-client/app/map/EventCallout.tsx
@@ -1,0 +1,18 @@
+import { SafeAreaView, Text } from "react-native";
+import { Callout } from "react-native-maps";
+import { EventMarker } from "../../types/types";
+
+interface Props {
+  eventData: EventMarker;
+}
+
+export function EventCallout({ eventData }: Props) {
+  return (
+    <Callout className="w-[300px] h-[100px] flex-1 relative">
+      <SafeAreaView>
+        <Text className="text-lg font-bold">{eventData.title}</Text>
+        <Text className="">{eventData.description}</Text>
+      </SafeAreaView>
+    </Callout>
+  );
+}

--- a/txcdr-client/app/map/EventCallout.tsx
+++ b/txcdr-client/app/map/EventCallout.tsx
@@ -6,6 +6,11 @@ interface Props {
   eventData: EventMarker;
 }
 
+/**
+ * Custom callout that displays a small event card on top of its annotation pin
+ * @param param0 Event data
+ * @returns React component
+ */
 export function EventCallout({ eventData }: Props) {
   return (
     <Callout className="w-[300px] h-[100px] flex-1 relative">

--- a/txcdr-client/app/map/Map.tsx
+++ b/txcdr-client/app/map/Map.tsx
@@ -2,6 +2,8 @@ import axios from "axios";
 import { useState, useEffect } from "react";
 import { SafeAreaView, TextInput } from "react-native";
 import MapView, { Region, Marker } from "react-native-maps";
+import { EventMarker } from "../../types/types";
+import { EventCallout } from "./EventCallout";
 
 export function Map() {
   // Keep track of selected region (based on ZIP code state)
@@ -42,10 +44,27 @@ export function Map() {
     }
   };
 
+  // Hard-coded markers (TODO: replace with actual data)
+  const markers: EventMarker[] = [
+    {
+      latlng: {
+        latitude: 29.717154,
+        longitude: -95.404182,
+      },
+      title: "Rice University",
+      description:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+    },
+  ];
+
   return (
     <SafeAreaView>
       <MapView className="w-full h-full" region={region}>
-        <Marker coordinate={{ latitude: 29.717154, longitude: -95.404182 }} />
+        {markers.map((marker, index) => (
+          <Marker key={index} coordinate={marker.latlng}>
+            <EventCallout eventData={marker} />
+          </Marker>
+        ))}
       </MapView>
       <SafeAreaView className="w-full top-7 absolute mx-auto flex items-center justify-center">
         <TextInput

--- a/txcdr-client/app/map/Map.tsx
+++ b/txcdr-client/app/map/Map.tsx
@@ -1,8 +1,7 @@
 import axios from "axios";
-import { Link } from "expo-router";
 import { useState, useEffect } from "react";
 import { SafeAreaView, TextInput } from "react-native";
-import MapView, { Region } from "react-native-maps";
+import MapView, { Region, Marker } from "react-native-maps";
 
 export function Map() {
   // Keep track of selected region (based on ZIP code state)
@@ -45,7 +44,9 @@ export function Map() {
 
   return (
     <SafeAreaView>
-      <MapView className="w-full h-full" region={region} />
+      <MapView className="w-full h-full" region={region}>
+        <Marker coordinate={{ latitude: 29.717154, longitude: -95.404182 }} />
+      </MapView>
       <SafeAreaView className="w-full top-7 absolute mx-auto flex items-center justify-center">
         <TextInput
           placeholder="Enter a ZIP code"

--- a/txcdr-client/app/map/Map.tsx
+++ b/txcdr-client/app/map/Map.tsx
@@ -5,6 +5,10 @@ import MapView, { Region, Marker } from "react-native-maps";
 import { EventMarker } from "../../types/types";
 import { EventCallout } from "./EventCallout";
 
+/**
+ * MapView component with ZIP code searching, markers, and callouts
+ * @returns MapView component
+ */
 export function Map() {
   // Keep track of selected region (based on ZIP code state)
   const [region, setRegion] = useState<Region>({

--- a/txcdr-client/app/map/Map.tsx
+++ b/txcdr-client/app/map/Map.tsx
@@ -1,0 +1,61 @@
+import axios from "axios";
+import { Link } from "expo-router";
+import { useState, useEffect } from "react";
+import { SafeAreaView, TextInput } from "react-native";
+import MapView, { Region } from "react-native-maps";
+
+export function Map() {
+  // Keep track of selected region (based on ZIP code state)
+  const [region, setRegion] = useState<Region>({
+    latitude: 0,
+    longitude: 0,
+    latitudeDelta: 0,
+    longitudeDelta: 0,
+  });
+
+  // Keep track of ZIP code input
+  const [zipCode, setZipCode] = useState("77005");
+
+  // Update the selected region when ZIP code state is changed
+  useEffect(() => {
+    // Use Google Maps Geocoding API (https://developers.google.com/maps/documentation/geocoding/overview)
+    axios
+      .get(
+        `https://maps.googleapis.com/maps/api/geocode/json?address=${zipCode}&key=${process.env.EXPO_PUBLIC_MAPS_KEY}`,
+      )
+      .then((res) => {
+        const { lat, lng }: { lat: number; lng: number } =
+          res.data.results[0].geometry.location;
+        setRegion({
+          latitude: lat,
+          longitude: lng,
+          latitudeDelta: 0.1,
+          longitudeDelta: 0.1,
+        });
+      })
+      .catch(() => console.log("Invalid ZIP code provided"));
+  }, [zipCode]);
+
+  // ZIP code text input handler
+  const onInputChange = (code: string) => {
+    if (code.length == 5 && /^[0-9]+$/.test(code)) {
+      setZipCode(code);
+    }
+  };
+
+  return (
+    <SafeAreaView>
+      <MapView className="w-full h-full" region={region} />
+      <SafeAreaView className="w-full top-7 absolute mx-auto flex items-center justify-center">
+        <TextInput
+          placeholder="Enter a ZIP code"
+          inputMode="numeric"
+          className="w-1/2 bg-gray-200 rounded-full py-2 mx-auto shadow-sm shadow-gray-600 text-lg text-center items-center text-gray-500 "
+          onChangeText={(e) => onInputChange(e)}
+          returnKeyType="done"
+          defaultValue={zipCode}
+        />
+      </SafeAreaView>
+    </SafeAreaView>
+  );
+}

--- a/txcdr-client/app/map/index.tsx
+++ b/txcdr-client/app/map/index.tsx
@@ -29,7 +29,8 @@ export default function Page() {
           latitudeDelta: 0.1,
           longitudeDelta: 0.1,
         });
-      });
+      })
+      .catch(() => console.log("Invalid ZIP code provided"));
   }, [zipCode]);
 
   const onInputChange = (code: string) => {

--- a/txcdr-client/app/map/index.tsx
+++ b/txcdr-client/app/map/index.tsx
@@ -23,7 +23,6 @@ export default function Page() {
       .then((res) => {
         const { lat, lng }: { lat: number; lng: number } =
           res.data.results[0].geometry.location;
-        console.log(lat, lng);
         setRegion({
           latitude: lat,
           longitude: lng,

--- a/txcdr-client/app/map/index.tsx
+++ b/txcdr-client/app/map/index.tsx
@@ -5,7 +5,12 @@ import MapView, { Region } from "react-native-maps";
 import axios from "axios";
 import { useEffect, useState } from "react";
 
+/**
+ * Main page component for the map page
+ * @returns React map page component
+ */
 export default function Page() {
+  // Keep track of selected region (based on ZIP code state)
   const [region, setRegion] = useState<Region>({
     latitude: 0,
     longitude: 0,
@@ -13,9 +18,12 @@ export default function Page() {
     longitudeDelta: 0,
   });
 
+  // Keep track of ZIP code input
   const [zipCode, setZipCode] = useState("77005");
 
+  // Update the selected region when ZIP code state is changed
   useEffect(() => {
+    // Use Google Maps Geocoding API (https://developers.google.com/maps/documentation/geocoding/overview)
     axios
       .get(
         `https://maps.googleapis.com/maps/api/geocode/json?address=${zipCode}&key=${process.env.EXPO_PUBLIC_MAPS_KEY}`,
@@ -33,6 +41,7 @@ export default function Page() {
       .catch(() => console.log("Invalid ZIP code provided"));
   }, [zipCode]);
 
+  // ZIP code text input handler
   const onInputChange = (code: string) => {
     if (code.length == 5 && /^[0-9]+$/.test(code)) {
       setZipCode(code);

--- a/txcdr-client/app/map/index.tsx
+++ b/txcdr-client/app/map/index.tsx
@@ -1,14 +1,55 @@
 import { Link } from "expo-router";
-import { Text } from "react-native";
+import { Text, TextInput } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import MapView from "react-native-maps";
+import MapView, { Region } from "react-native-maps";
+import axios from "axios";
+import { useEffect, useState } from "react";
 
 export default function Page() {
+  const [region, setRegion] = useState<Region>({
+    latitude: 0,
+    longitude: 0,
+    latitudeDelta: 0,
+    longitudeDelta: 0,
+  });
+
+  const [zipCode, setZipCode] = useState("77005");
+
+  useEffect(() => {
+    axios
+      .get(
+        `https://maps.googleapis.com/maps/api/geocode/json?address=${zipCode}&key=${process.env.EXPO_PUBLIC_MAPS_KEY}`,
+      )
+      .then((res) => {
+        const { lat, lng }: { lat: number; lng: number } =
+          res.data.results[0].geometry.location;
+        console.log(lat, lng);
+        setRegion({
+          latitude: lat,
+          longitude: lng,
+          latitudeDelta: 0.1,
+          longitudeDelta: 0.1,
+        });
+      });
+  }, [zipCode]);
+
+  const onInputChange = (code: string) => {
+    if (code.length == 5 && /^[0-9]+$/.test(code)) {
+      setZipCode(code);
+    }
+  };
+
   return (
     <SafeAreaView>
       <Text className="text-2xl">Map page</Text>
       <Link href="/">Go back to home page</Link>
-      <MapView className="w-full h-full" />
+      <TextInput
+        placeholder="Enter a ZIP code"
+        keyboardType="numbers-and-punctuation"
+        className="w-1/2 mx-auto bg-gray-300 rounded-full px-5 py-2"
+        onChangeText={(e) => onInputChange(e)}
+      />
+      <MapView className="w-full h-full" region={region} />
     </SafeAreaView>
   );
 }

--- a/txcdr-client/app/map/index.tsx
+++ b/txcdr-client/app/map/index.tsx
@@ -11,7 +11,7 @@ export default function Page() {
   return (
     <SafeAreaView>
       <Text className="text-2xl">Map page</Text>
-      <Link href="/" className="py-1">
+      <Link href="/" className="py-3">
         Go back to home page
       </Link>
       <Map />

--- a/txcdr-client/app/map/index.tsx
+++ b/txcdr-client/app/map/index.tsx
@@ -1,5 +1,5 @@
 import { Link } from "expo-router";
-import { Text, TextInput } from "react-native";
+import { Text, TextInput, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import MapView, { Region } from "react-native-maps";
 import axios from "axios";
@@ -42,13 +42,16 @@ export default function Page() {
     <SafeAreaView>
       <Text className="text-2xl">Map page</Text>
       <Link href="/">Go back to home page</Link>
-      <TextInput
-        placeholder="Enter a ZIP code"
-        keyboardType="numbers-and-punctuation"
-        className="w-1/2 mx-auto bg-gray-300 rounded-full px-5 py-2"
-        onChangeText={(e) => onInputChange(e)}
-      />
+
       <MapView className="w-full h-full" region={region} />
+      <SafeAreaView className="w-full top-20 absolute mx-auto flex items-center justify-center">
+        <TextInput
+          placeholder="Enter a ZIP code"
+          keyboardType="numbers-and-punctuation"
+          className="w-3/5 bg-gray-300 rounded-full px-5 py-2 mx-auto shadow-sm shadow-gray-600 text-xl text-center "
+          onChangeText={(e) => onInputChange(e)}
+        />
+      </SafeAreaView>
     </SafeAreaView>
   );
 }

--- a/txcdr-client/app/map/index.tsx
+++ b/txcdr-client/app/map/index.tsx
@@ -1,71 +1,20 @@
 import { Link } from "expo-router";
-import { Text, TextInput, View } from "react-native";
+import { Text } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import MapView, { Region } from "react-native-maps";
-import axios from "axios";
-import { useEffect, useState } from "react";
+import { Map } from "./Map";
 
 /**
  * Main page component for the map page
  * @returns React map page component
  */
 export default function Page() {
-  // Keep track of selected region (based on ZIP code state)
-  const [region, setRegion] = useState<Region>({
-    latitude: 0,
-    longitude: 0,
-    latitudeDelta: 0,
-    longitudeDelta: 0,
-  });
-
-  // Keep track of ZIP code input
-  const [zipCode, setZipCode] = useState("77005");
-
-  // Update the selected region when ZIP code state is changed
-  useEffect(() => {
-    // Use Google Maps Geocoding API (https://developers.google.com/maps/documentation/geocoding/overview)
-    axios
-      .get(
-        `https://maps.googleapis.com/maps/api/geocode/json?address=${zipCode}&key=${process.env.EXPO_PUBLIC_MAPS_KEY}`,
-      )
-      .then((res) => {
-        const { lat, lng }: { lat: number; lng: number } =
-          res.data.results[0].geometry.location;
-        setRegion({
-          latitude: lat,
-          longitude: lng,
-          latitudeDelta: 0.1,
-          longitudeDelta: 0.1,
-        });
-      })
-      .catch(() => console.log("Invalid ZIP code provided"));
-  }, [zipCode]);
-
-  // ZIP code text input handler
-  const onInputChange = (code: string) => {
-    if (code.length == 5 && /^[0-9]+$/.test(code)) {
-      setZipCode(code);
-    }
-  };
-
   return (
     <SafeAreaView>
       <Text className="text-2xl">Map page</Text>
       <Link href="/" className="py-1">
         Go back to home page
       </Link>
-
-      <MapView className="w-full h-full" region={region} />
-      <SafeAreaView className="w-full top-20 absolute mx-auto flex items-center justify-center">
-        <TextInput
-          placeholder="Enter a ZIP code"
-          inputMode="numeric"
-          className="w-1/2 bg-gray-200 rounded-full py-2 mx-auto shadow-sm shadow-gray-600 text-lg text-center items-center text-gray-500 "
-          onChangeText={(e) => onInputChange(e)}
-          returnKeyType="done"
-          defaultValue={zipCode}
-        />
-      </SafeAreaView>
+      <Map />
     </SafeAreaView>
   );
 }

--- a/txcdr-client/app/map/index.tsx
+++ b/txcdr-client/app/map/index.tsx
@@ -1,12 +1,14 @@
 import { Link } from "expo-router";
 import { Text } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import MapView from "react-native-maps";
 
 export default function Page() {
   return (
     <SafeAreaView>
       <Text className="text-2xl">Map page</Text>
       <Link href="/">Go back to home page</Link>
+      <MapView className="w-full h-full" />
     </SafeAreaView>
   );
 }

--- a/txcdr-client/app/map/index.tsx
+++ b/txcdr-client/app/map/index.tsx
@@ -41,15 +41,19 @@ export default function Page() {
   return (
     <SafeAreaView>
       <Text className="text-2xl">Map page</Text>
-      <Link href="/">Go back to home page</Link>
+      <Link href="/" className="py-1">
+        Go back to home page
+      </Link>
 
       <MapView className="w-full h-full" region={region} />
       <SafeAreaView className="w-full top-20 absolute mx-auto flex items-center justify-center">
         <TextInput
           placeholder="Enter a ZIP code"
-          keyboardType="numbers-and-punctuation"
-          className="w-3/5 bg-gray-300 rounded-full px-5 py-2 mx-auto shadow-sm shadow-gray-600 text-xl text-center "
+          inputMode="numeric"
+          className="w-1/2 bg-gray-200 rounded-full py-2 mx-auto shadow-sm shadow-gray-600 text-lg text-center items-center text-gray-500 "
           onChangeText={(e) => onInputChange(e)}
+          returnKeyType="done"
+          defaultValue={zipCode}
         />
       </SafeAreaView>
     </SafeAreaView>

--- a/txcdr-client/package-lock.json
+++ b/txcdr-client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "txcdr-client",
       "version": "1.0.0",
       "dependencies": {
+        "axios": "^1.6.0",
         "expo": "~49.0.15",
         "expo-constants": "~14.4.2",
         "expo-linking": "~5.0.2",
@@ -6391,6 +6392,29 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/axios": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -8325,6 +8349,25 @@
       "integrity": "sha512-HVzoK3r6Vsg+lKvlIZzaWNBVai+FXTX1wdYhz/wVlH13tb/gOdLXmlTqy6odmTBhT5UoWUbq0k8263Qhr9d88w==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fontfaceobserver": {
@@ -12380,6 +12423,11 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.0",

--- a/txcdr-client/package-lock.json
+++ b/txcdr-client/package-lock.json
@@ -17,6 +17,7 @@
         "react": "18.2.0",
         "react-native": "0.72.6",
         "react-native-gesture-handler": "~2.12.0",
+        "react-native-maps": "1.7.1",
         "react-native-safe-area-context": "4.6.3",
         "react-native-screens": "~3.22.0"
       },
@@ -6025,6 +6026,11 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.12",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.12.tgz",
+      "integrity": "sha512-uK2z1ZHJyC0nQRbuovXFt4mzXDwf27vQeUWNhfKGwRcWW429GOhP8HxUHlM6TLH4bzmlv/HlEjpvJh3JfmGsAA=="
     },
     "node_modules/@types/hammerjs": {
       "version": "2.0.43",
@@ -12664,6 +12670,24 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.7.1.tgz",
+      "integrity": "sha512-CHVLzL+Q2jiUGgbt4/vosxVI1SukWyaLGjD62VLgR/wZpnH4Umi9ql1bmKDPWcfj2C1QZwMU0Yc7rXTbvZUIiw==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10"
+      },
+      "peerDependencies": {
+        "react": ">= 17.0.1",
+        "react-native": ">= 0.64.3",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/txcdr-client/package.json
+++ b/txcdr-client/package.json
@@ -10,6 +10,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "axios": "^1.6.0",
     "expo": "~49.0.15",
     "expo-constants": "~14.4.2",
     "expo-linking": "~5.0.2",
@@ -19,9 +20,9 @@
     "react": "18.2.0",
     "react-native": "0.72.6",
     "react-native-gesture-handler": "~2.12.0",
+    "react-native-maps": "1.7.1",
     "react-native-safe-area-context": "4.6.3",
-    "react-native-screens": "~3.22.0",
-    "react-native-maps": "1.7.1"
+    "react-native-screens": "~3.22.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/txcdr-client/package.json
+++ b/txcdr-client/package.json
@@ -20,7 +20,8 @@
     "react-native": "0.72.6",
     "react-native-gesture-handler": "~2.12.0",
     "react-native-safe-area-context": "4.6.3",
-    "react-native-screens": "~3.22.0"
+    "react-native-screens": "~3.22.0",
+    "react-native-maps": "1.7.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/txcdr-client/types/types.tsx
+++ b/txcdr-client/types/types.tsx
@@ -1,5 +1,5 @@
 /**
- * Data for an annotation pin's event card
+ * Data for event markers on the map
  */
 export interface EventMarker {
   latlng: {

--- a/txcdr-client/types/types.tsx
+++ b/txcdr-client/types/types.tsx
@@ -1,0 +1,11 @@
+/**
+ * Data for an annotation pin's event card
+ */
+export interface EventMarker {
+  latlng: {
+    latitude: number;
+    longitude: number;
+  };
+  title: string;
+  description: string;
+}


### PR DESCRIPTION
## Additions
- `MapView` component in `/map` page
- ZIP code search bar overlaid on top of map
- Dummy pin (one on top of Rice)
- Dummy event card (appears when you click the pin)
- `types/types.tsx` for frontend types

## Testing
Tested with Expo on Pixel 3a emulator and iPhone X (iOS 16.3.1)